### PR TITLE
Publish only once when sending multiple responses concurrently.

### DIFF
--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -368,7 +368,8 @@ MessageBus.prototype.sendResponse = function(msgId, status, msg){
             delete that.idToChannelMap[msgId];
         }
 
-        if (err){
+        if(err) {
+            that.pending[msgId] -= 1;
             throw new Error(err);
         }
 

--- a/test/test-messaging.js
+++ b/test/test-messaging.js
@@ -413,6 +413,43 @@ describe('messaging', function(){
                 }, 1000);
             });
 
+
+            it('should publish only once on concurrent messaging, with errors.', function(done) {
+                var pubStub  = sinon.stub(mBusWorker.pubClient, 'publish')
+                  , msgId    = messaging.makeId()
+                  , testMode = true;
+
+                // Force `hset` to throw an error to verify that publish is
+                // called even when one of the concurrent request fails.
+                var errors   = 0;
+                var dataStub = sinon.stub(mBusWorker.dataClient, 'hset', function(hash, msgId, msg, fn) {
+                    try {
+                        if(JSON.parse(msg).error) {
+                            errors += 1;
+                            fn(new Error('Test error'));
+                        }
+                        else {
+                            fn(null, true);
+                        }
+                    }
+                    catch(e) {
+                        // Ignore exceptions.
+                    }
+                });
+
+                mBusWorker.sendResponse(msgId, 'PROGRESS', { error: true },  testMode);
+                mBusWorker.sendResponse(msgId, 'PROGRESS', { error: true },  testMode);
+                mBusWorker.sendResponse(msgId, 'SUCCESS',  { error: false }, testMode);
+
+                setTimeout(function() {
+                    errors.should.equal(2);// Exceptions should have been thrown.
+                    pubStub.callCount.should.equal(1);
+                    pubStub.restore();
+                    dataStub.restore();
+                    done();
+                }, 1000);
+            });
+
         });
 
         describe('#makeId', function(){


### PR DESCRIPTION
With the addition of progress events, data will be `hset` on the same `msgId` multiple times.

If two events are submitted concurrently, `hset` will be called twice, but because of the asynchrony, both `hset`s will complete before it is published. Thus, publish is called twice, while there was really only one update (the second `hset`).

This commit makes sure publish is only called when the last concurrent `hset` completes. Given redis processes commands in order [1], this works well.

[1] http://stackoverflow.com/a/12344714
