### PR TITLE
 Make sure progressBus is ready when new task is received.

### DIFF
--- a/lib/background_task.js
+++ b/lib/background_task.js
@@ -297,12 +297,13 @@ exports.connect = (function(){
 
                 timeoutId = setTimeout(timedoutCb, taskTimeout);
 
-                that.msgBus.sendMessage(id, msgToSend, cb);
-                that.progressBus.sendMessage(id, msgToSend, function(reply) {
-                  if (reply instanceof Error) {
-                    console.log("ProgressBus SendMessage error:\n");
-                    console.log(util.inspect(reply));
-                  }
+                // progressBus needs to be ready when msgBus is set-up.
+                that.progressBus.sendMessage(id, msgToSend, function() { }, function(reply) {
+                    if(reply instanceof Error) {
+                        console.log("ProgressBus SendMessage error:\n");
+                        console.log(util.inspect(reply));
+                    }
+                    that.msgBus.sendMessage(id, msgToSend, cb);
                 });
 
                 that.msgBus.once('responseReady:' + id,responseCb);

--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -236,7 +236,7 @@ completeTransaction = function(that, ch, msg){
 
 };
 
-MessageBus.prototype.sendMessage = function(id, msg, callback){
+MessageBus.prototype.sendMessage = function(id, msg, callback, doneCb){
     var that = this
       , err
       , msgString;
@@ -263,6 +263,11 @@ MessageBus.prototype.sendMessage = function(id, msg, callback){
     }
 
     this.dataClient.hset(this.dataHash, id, msgString, function(err, reply){
+        // We’re done.
+        if(doneCb) {
+            doneCb();
+        }
+
         if (err){
             callback(new Error("Error sending message: " + err));
             return;


### PR DESCRIPTION
Fixes the following scenario:
- msgBus sendMessage publishes.
- progressBus sendMessage is called, but hasn’t published yet.
- event is received by worker, task is handled.
- task calls reportProgress.
- "Attempt to respond to message that was never accepted" error occurs, because progressBus sendMessage hasn’t published yet.

In short, the progress bus needs to be ready when events are received and handled by workers. Fixed by this pull request.
