### PR TITLE
Drop progress notifications on failure.

### DIFF
--- a/lib/task_client.js
+++ b/lib/task_client.js
@@ -133,10 +133,12 @@ exports.initialize = function (options) {
     // ProcessNotification to retrieve the data
     that.notificationBus.processNotification(id, status, function (err, result) {
       if (err) {
-        endTask(id, taskCallback);
-        that.taskLimit.stopTask(that.msgMap[id], function(err, result) {
+        // Silently drop progress events if an error occurred.
+        if (status === "PROGRESS") {
+          return;
+        }
 
-        });
+        that.taskLimit.stopTask(that.msgMap[id]);
         cleanupMaps(that, id);
         clearTimeout(that.taskTimeouts[id]);
         taskCallback(id, err);
@@ -162,22 +164,6 @@ exports.initialize = function (options) {
       if (taskCallback) {
         taskCallback(reply.id, reply.details);
       }
-    });
-  };
-
-  var endTask = function (id, taskCallback) {
-    var that = this, callbackMsg;
-
-    that.taskLimit.stopTask(that.msgMap[id], function(err, result) {
-      if (err) {
-        callbackMsg = err;
-      } else {
-        callbackMsg = result;
-      }
-
-      cleanupMaps(that, id);
-      clearTimeout(that.taskTimeouts[id]);
-      taskCallback(id, callbackMsg);
     });
   };
 


### PR DESCRIPTION
When a progress notification cannot be processed, it is OK to just drop it and not stop the task altogether.

This also fixes an issue where `stopTask` was invoked twice (via the `endTask` method, and in the `processNotification` body as well).
