### PR TITLE
Fixes bugs with redis error handling

### DIFF
--- a/lib/notification_bus.js
+++ b/lib/notification_bus.js
@@ -136,16 +136,19 @@ exports.initialize = function (options, callback) {
     this.shutdownFlag = false;
     this.id = makeId();        // For debugging / logging
 
-    // Intitializing connections to the dataStore and to redis
+    // Initializing connections to the dataStore and to redis.
     var functions = [
       function (cb) {
         that.subClient = redis.initialize(options, cb);
+        that.subClient.on('taskError', common.wrapError(that));
       },
       function (cb) {
         that.pubClient = redis.initialize(options, cb);
+        that.pubClient.on('taskError', common.wrapError(that));
       },
       function (cb) {
         that.dataClient = dataStore.initialize(options, cb);
+        that.dataClient.on('taskError', common.wrapError(that));
       }
     ];
 
@@ -157,16 +160,6 @@ exports.initialize = function (options, callback) {
         initCreator(that);
       }
 
-      // Handle error events
-      that.dataClient.on('taskError', function (evt) {
-        common.wrapError(evt);
-      });
-      that.pubClient.on('taskError', function (evt) {
-        common.wrapError(evt);
-      });
-      that.subClient.on('taskError', function (evt) {
-        common.wrapError(evt);
-      });
       if (callback) {
         callback();
       }

--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -48,8 +48,6 @@ exports.initialize = function (options, callback) {
       redisOptions.auth_pass = this.redisPassword;
     }
 
-
-
     // Create the redis client
     this.client = redis.createClient(this.redisPort, this.redisHost, redisOptions);
 
@@ -64,7 +62,7 @@ exports.initialize = function (options, callback) {
 
     // Emit all error events
     this.client.on('error', function (evt) {
-      this.emit('taskError', evt);
+      that.emit('taskError', evt);
     });
   };
 

--- a/test/test-notification_bus.js
+++ b/test/test-notification_bus.js
@@ -147,7 +147,8 @@ describe('messaging', function(){
     describe('Error Handling', function(){
       it('should emit an error when redis is not available.', function(done) {
         notificationBus = notification.initialize({ host: 'example' }, function() { });
-        notificationBus.on('error', function(evt) {
+        notificationBus.on('error', function(err) {
+          err.message.should.match(/ENOTFOUND/); // Host `example` does not exist.
           notificationBus.shutdown(); // Stop now to avoid more error events.
           done();
         });

--- a/test/test-notification_bus.js
+++ b/test/test-notification_bus.js
@@ -145,6 +145,14 @@ describe('messaging', function(){
     });
 
     describe('Error Handling', function(){
+      it('should emit an error when redis is not available.', function(done) {
+        notificationBus = notification.initialize({ host: 'example' }, function() { });
+        notificationBus.on('error', function(evt) {
+          notificationBus.shutdown(); // Stop now to avoid more error events.
+          done();
+        });
+      });
+
       it('should handle bad items on the worker queue', function(done){
         var status= "biwq";
         var nBus = notification.initialize({isWorker: true, broadcastChannel: "biwqC"}, function() {


### PR DESCRIPTION
Previously, errors originating from redis (i.e. `ECONNREFUSED`) did not propagate properly to the `notificationBus`. This PR fixes this, and adds a test for this as well.

_NOTE_ - The `taskError` listeners in `lib/notification_bus.js` are attached directly after creating the client to catch any connect-related errors.
