### PR TITLE
KDEV-360: Update ioredis in order to remove hiredis dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "background-task",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,20 +9,15 @@
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "cluster-key-slot": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz",
-      "integrity": "sha1-dlRVYIWmUzCTKi6LWXb44tCz5BQ="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "commander": {
       "version": "2.3.0",
@@ -31,23 +26,23 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "escape-string-regexp": {
       "version": "1.0.2",
@@ -66,7 +61,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "glob": {
@@ -75,9 +70,9 @@
       "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
       "dev": true,
       "requires": {
-        "graceful-fs": "2.0.3",
-        "inherits": "2.0.3",
-        "minimatch": "0.2.14"
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
       }
     },
     "graceful-fs": {
@@ -92,15 +87,6 @@
       "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
       "dev": true
     },
-    "hiredis": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.5.0.tgz",
-      "integrity": "sha1-2wOpi+zXAD0TwmAEOs7s+s31m4c=",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.6.2"
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -108,18 +94,33 @@
       "dev": true
     },
     "ioredis": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.2.tgz",
-      "integrity": "sha1-Pw4McZnd2cfolipR/rvijez1x2E=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
+      "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
       "requires": {
-        "bluebird": "3.5.0",
-        "cluster-key-slot": "1.0.8",
-        "debug": "2.6.8",
-        "double-ended-queue": "2.1.0-0",
+        "bluebird": "^3.3.4",
+        "cluster-key-slot": "^1.0.6",
+        "debug": "^2.6.9",
+        "denque": "^1.1.0",
         "flexbuffer": "0.0.6",
-        "lodash": "4.17.4",
-        "redis-commands": "1.3.1",
-        "redis-parser": "1.3.0"
+        "lodash.assign": "^4.2.0",
+        "lodash.bind": "^4.2.1",
+        "lodash.clone": "^4.5.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.keys": "^4.2.0",
+        "lodash.noop": "^3.0.1",
+        "lodash.partial": "^4.2.1",
+        "lodash.pick": "^4.4.0",
+        "lodash.sample": "^4.2.1",
+        "lodash.shuffle": "^4.2.0",
+        "lodash.values": "^4.3.0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.4.0"
       }
     },
     "jade": {
@@ -146,15 +147,90 @@
         }
       }
     },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isnil": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
       "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+    },
+    "lodash.noop": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
+      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
+    },
+    "lodash.partial": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-4.2.1.tgz",
+      "integrity": "sha1-SfPYz9qjv/izqR0SfpIyRUGJYdQ="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.sample": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
+      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20="
+    },
+    "lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha1-FFtQU8+HX29cKjP0i26ZSMbse0s="
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
     "lolex": {
       "version": "1.3.2",
@@ -174,8 +250,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -238,25 +314,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-    },
     "precond": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.2.tgz",
       "integrity": "sha1-xs5xf5CefdCgjVFfn7QoBB1vmS4="
     },
     "redis-commands": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
     },
     "redis-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
-      "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "samsam": {
       "version": "1.1.2",
@@ -314,7 +385,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.3"
+        "util": ">=0.10.3 <1"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "background-task",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Distributed task execution framework for node, backed by redis.",
   "main": "index.js",
   "author": "Kinvey <support@kinvey.com>",
@@ -29,8 +29,7 @@
     "async": "0.2.10",
     "lodash.isnil": "4.0.0",
     "precond": "0.2.2",
-    "ioredis":"2.4.2",
-    "hiredis":"0.5.0",
+    "ioredis": "3.2.2",
     "uuid": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The hiredis dep requires node-gyp and is failing against newer Node versions.

The hiredis dep is optional and was used as a faster ioredis parser prior ioredis version 3.

The version 3 update does not seem to have breaking changes from looking at the changelog: https://github.com/luin/ioredis/releases?after=v4.0.0-0